### PR TITLE
Add error catch on async function

### DIFF
--- a/scripts/simulateFunctionsJavaScript.js
+++ b/scripts/simulateFunctionsJavaScript.js
@@ -1,16 +1,19 @@
 const { simulateRequest, getDecodedResultLog, getRequestConfig } = require("../FunctionsSandboxLibrary")
 
 const runSimulation = async (requestConfig) => {
-  const { resultLog, result, success } = await simulateRequest(requestConfig)
-
-  console.log(`\n${resultLog}`)
-  if (success) {
-    console.log(`Value returned from source code: ${result}\n${getDecodedResultLog(requestConfig, result)}`)
-    return
+  try {
+    const { resultLog, result, success } = await simulateRequest(requestConfig);
+    console.log(`\n${resultLog}`);
+    if (success) {
+      console.log(`Value returned from source code: ${result}\n${getDecodedResultLog(requestConfig, result)}`);
+      return;
+    }
+  } catch (error) {
+    console.error("Error running simulation:", error);
   }
-}
+};
 
-;(async () => {
+(async () => {
   const unvalidatedRequestConfig = require("../Functions-request-config.js")
   const requestConfig = getRequestConfig(unvalidatedRequestConfig)
 


### PR DESCRIPTION
### **Add Error Handling**

File Path: scripts/simulateFunctionsJavaScript.js

Code Line: Line3 ~ Line 11

There is no error handling around the `simulateRequest `call or around other async invocations . If the request simulation fails, the process will simply terminate without any error logging, which could lead to harder-to-debug scenarios in production.

Suggestion: Add `try-catch` blocks around the async calls to gracefully handle potential errors.